### PR TITLE
Handle auth and data errors

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -79,21 +79,16 @@ def serve_layout():
 
     # ignore cache and request again, if data is not formed correctly.
     try:
-        if 1 not in api_json  or 'data' not in api_json[1] or 'consort' not in api_json[1]['data']:
+        app.logger.info(api_json)
+        if 'data' not in api_json or 'consort' not in api_json['data']:
             app.logger.info('Requesting data from api {0} to ignore cache.'.format(api_address))
             api_json = get_api_data(api_address, True)
     except KeyError:
         app.logger.info('Requesting data from api {0} to ignore cache.'.format(api_address))
         api_json = get_api_data(api_address, True)
 
-    if api_json[0]==200:
-        consort_data = api_json[1]['data']['consort']
-        report_title = html.Div([html.H1('CONSORT REPORT')])
-    else:
-        app.logger.warn('api failed')
-        consort_data = latest_data
-        report_title = html.Div([html.H1('CONSORT REPORT (sample data)'), 
-                                 html.P('Current data unavailable')])
+    consort_data = api_json['data']['consort']
+    report_title = html.Div([html.H1('CONSORT REPORT')])
 
     layout =  html.Div([
         html.Div([

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,6 @@
 # File Management
 import os # Operating system library
+import flask
 import pathlib # file paths
 
 # Data Cleaning and transformations
@@ -56,7 +57,7 @@ def get_api_data(api_address):
     api_json = {}
     try:
         try:
-            response = requests.get(api_address)
+            response = requests.get(api_address, cookies=flask.request.cookies)
         except:
             return('error: {}'.format(e))
         request_status = response.status_code

--- a/src/app.py
+++ b/src/app.py
@@ -79,7 +79,7 @@ def serve_layout():
 
     # ignore cache and request again, if data is not formed correctly.
     try:
-        app.logger.info(api_json)
+        app.logger.debug(api_json)
         if 'data' not in api_json or 'consort' not in api_json['data']:
             app.logger.info('Requesting data from api {0} to ignore cache.'.format(api_address))
             api_json = get_api_data(api_address, True)
@@ -156,11 +156,11 @@ def show_store_data(mcc, api_data):
     df_json = api_data
     error_div = html.Div('There is no data available for this selection')
     
-    print(mcc)
+    app.logger.info('Selected mcc - {0}'.format(mcc))
     if not mcc:
         return html.Div('Please select an mcc to view data')
     if not df_json:
-        print('no df')
+        app.logger.info('no df')
         return error_div
     else:
         df = pd.DataFrame.from_dict(df_json)

--- a/src/app.py
+++ b/src/app.py
@@ -71,14 +71,18 @@ def serve_layout():
             if error_code in ('MISSING_SESSION_ID', 'INVALID_TAPIS_TOKEN'):
                 app.logger.warn('Auth error from datastore, asking user to authenticate')
                 return html.Div([html.H1('CONSORT REPORT'),
-                                         html.H4('Please login and authenticate on the portal to access the report.')])
+                                         html.H4('Please login and authenticate on the portal to access the report.')],style=TACC_IFRAME_SIZE)
             else:
-                report_title = html.Div([html.H1('CONSORT REPORT (sample data)'), 
-                                 html.P('Current data unavailable')])
+                return html.Div([html.H1('CONSORT REPORT (sample data)'), 
+                                 html.P('Current data unavailable')],style=TACC_IFRAME_SIZE)
 
 
-    # ignore cache and request again.
-    if 'data' not in api_json[1] or 'consort' not in api_json[1]['data']:
+    # ignore cache and request again, if data is not formed correctly.
+    try:
+        if 1 not in api_json  or 'data' not in api_json[1] or 'consort' not in api_json[1]['data']:
+            app.logger.info('Requesting data from api {0} to ignore cache.'.format(api_address))
+            api_json = get_api_data(api_address, True)
+    except KeyError:
         app.logger.info('Requesting data from api {0} to ignore cache.'.format(api_address))
         api_json = get_api_data(api_address, True)
 

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@
 import os # Operating system library
 import flask
 import pathlib # file paths
+import logging
 
 # Data Cleaning and transformations
 import pandas as pd

--- a/src/datastore_loading.py
+++ b/src/datastore_loading.py
@@ -1,4 +1,5 @@
 import os
+import flask
 import requests
 import json
 import traceback
@@ -17,7 +18,7 @@ def get_api_data(api_address):
     api_json = {}
     try:
         try:
-            response = requests.get(api_address)
+            response = requests.get(api_address, cookies=flask.request.cookies)
         except:
             return('error: {}'.format(e))
         request_status = response.status_code

--- a/src/datastore_loading.py
+++ b/src/datastore_loading.py
@@ -9,25 +9,25 @@ import traceback
 # ---------------------------------
 DATASTORE_URL = os.environ.get("DATASTORE_URL","url not found")
 DATASTORE_URL = os.path.join(DATASTORE_URL, "api/")
+logger  = logging.getLogger("imaging_app")
 
 # ---------------------------------
 #   Get Data From datastore
 # ---------------------------------
 
-def get_api_data(api_address):
+class PortalAuthException(Exception):
+    '''Custom Exception for issues with Authentication'''
+
+def get_api_data(api_address, ignore_cache=False):
     api_json = {}
     try:
-        try:
-            response = requests.get(api_address, cookies=flask.request.cookies)
-        except:
-            return('error: {}'.format(e))
-        request_status = response.status_code
-        if request_status == 200:
-            api_json = response.json()
-            return api_json
-        else:
-            return request_status
+        params = {}
+        if ignore_cache:
+            params = {'ignore_cache':True}
+        response = requests.get(api_address, params=params, cookies=flask.request.cookies)
+        response.raise_for_status()
+        return response.json()
     except Exception as e:
-        traceback.print_exc()
+        logger.warn(e)
         api_json['json'] = 'error: {}'.format(e)
         return api_json

--- a/src/datastore_loading.py
+++ b/src/datastore_loading.py
@@ -1,8 +1,7 @@
 import os
 import flask
 import requests
-import json
-import traceback
+import logging
 
 # ---------------------------------
 #   MOVE THIS TO REFERENCE FROM ENV
@@ -14,9 +13,6 @@ logger  = logging.getLogger("imaging_app")
 # ---------------------------------
 #   Get Data From datastore
 # ---------------------------------
-
-class PortalAuthException(Exception):
-    '''Custom Exception for issues with Authentication'''
 
 def get_api_data(api_address, ignore_cache=False):
     api_json = {}


### PR DESCRIPTION
## Overview
When authentication fails or user is not authenticated, provide a message to user to authenticate in the portal
When data is invalid, try again by bypassing cache.
## Related
Corresponding change: https://github.com/TACC/a2cps-datastore/pull/8

## Testing
Try it out at: https://dev.a2cps.tacc.utexas.edu/reports/consort-report-latest/
delete coresessionid cookie in dev tools to simulate session issue.